### PR TITLE
Run qa fixes

### DIFF
--- a/python/qx_utilities/qa/config.py
+++ b/python/qx_utilities/qa/config.py
@@ -309,6 +309,11 @@ def recursive_parse(name, template, config):
     #keys in template that haven't been parsed
     remaining_keys = set(template['parameters'].keys()).difference(set(p_config.keys()))
     for r_key in remaining_keys:
+
+        #Parameters with an ID (eg. scan`,other) only want to be parsed if specified in the config
+        if 'ID' in template['parameters'][r_key].keys():
+            continue
+
         if template['parameters'][r_key]['required']:
             raise ge.CommandError(
                 "run_qa",

--- a/python/qx_utilities/qa/core.py
+++ b/python/qx_utilities/qa/core.py
@@ -77,6 +77,8 @@ class QA:
             sessionsfolder = os.path.join(os.getcwd(),sessionsfolder)
         self.sessionsfolder = sessionsfolder
 
+        self.report_empty = True
+
         self.report = "=========================================="
         self.report += "\n              QA report"
         self.report += "\n=========================================="
@@ -512,6 +514,9 @@ class QA:
                 self.update_report(s)
             else:
                 print(f"{s['id']} has passed QA!")
+
+        if self.report_empty:
+            self.report += "\n\nAll session(s) passed QA!"
         return
     
     def nifti_qa(self, s, image_id, scans, config):
@@ -679,6 +684,8 @@ class QA:
         --s (dict)
             slist dict that has failed QA
         """
+
+        self.report_empty = False
         
         for image_id, fail in s['QA_image_fail'].items():
             self.report+= f"\n   - {image_id}"


### PR DESCRIPTION
Fixed a severe bug with run_qa that prevented config being parsed. Added success text to QA report to reduce confusion.