### PR TITLE
fix: typo

### DIFF
--- a/matlab/qx_mri/general/general_read_file_list.m
+++ b/matlab/qx_mri/general/general_read_file_list.m
@@ -136,7 +136,7 @@ if ischar(flist)
             list.session(nsessions).conc = strtrim(s(2:end));
         elseif ~isempty(strfind(s, 'fidl:'))
             [t, s] = strtok(s, ':');
-            slist.ession(nsessions).fidl = strtrim(s(2:end));
+            list.session(nsessions).fidl = strtrim(s(2:end));
         elseif ~isempty(strfind(s, 'glm:'))
             [t, s] = strtok(s, ':');
             list.session(nsessions).glm = strtrim(s(2:end));


### PR DESCRIPTION
Typo preventing .fidl files being parsed correctly