### PR TITLE
fix: log bookkeeping in run_with_log, process.py and gmri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 ## 1.5.0
 
+* Fixed a set of log bookkeeping bugs: the runlog folder is no longer mis-derived for study paths containing `comlogs`, the session id is written to the runlog instead of the console, the final report of a parallel run again shows the log path, and serial runs no longer record a spurious "Unknown" status next to the real one for every session.
 * Added NHP (non-human primate) support to all HCP commands that now support it. This is mainly accessible through the `hcp_species` parameter, while there is a completely new command for HCP FreeSurfer (`hcp_nhp_freesurfer`).
 * Log structure rework, logs are now in the logs folder in the study and are group per each command invocation.
 * QuNex study structure is now simplified, only a couple of core folders will be created initially, others are added as needed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,10 @@ Quality:
   public functions.
 - Explicit error handling with actionable messages. Avoid hidden side effects and global state.
 - Prefer `except Exception:` over a bare `except:` (a bare except also swallows KeyboardInterrupt).
-- Keep imports clean and grouped. Note: the package uses flat imports (e.g.
-  `from general import core as gc`) — `pythonpath = python/qx_utilities` is set in `pytest.ini`.
+- Keep imports clean and grouped. The package uses absolute `qx_utilities.*` imports
+  (e.g. `import qx_utilities.general.core as gc`), introduced with the command registry —
+  `pythonpath = python` is set in `pytest.ini` at the repository root. Do not add flat
+  imports (`from general import core as gc`); there are none left in the tree.
 - Before deleting a seemingly-unused function, confirm it is not a dynamic/external entrypoint:
   registered commands (a `.. qx_command:` docstring, called via the registry) and the
   `@qx_process` extension decorator in `general/extensions.py` (used by out-of-tree extensions

--- a/python/qx_utilities/general/core.py
+++ b/python/qx_utilities/general/core.py
@@ -905,17 +905,14 @@ def run_with_log(function, args=None, logfile=None, name=None, prepend=""):
     except ge.CommandError as e:
         with lock:
             print(ge.report_command_error(name, e))
-            print
         result = e
     except ge.CommandNull as e:
         with lock:
             print(ge.report_command_null(name, e))
-            print
         result = e
     except ge.CommandFailed as e:
         with lock:
             print(ge.report_command_failed(name, e))
-            print
         result = e
     except Exception as e:
         with lock:
@@ -949,9 +946,10 @@ def run_with_log(function, args=None, logfile=None, name=None, prepend=""):
 
         os.rename(os.path.join(logfolder, "tmp_" + logname), comlogname)
 
-        # create runlog
-        if "comlogs" in logfolder:
-            logfolder = logfolder.replace("comlogs", "")
+        # create runlog, which sits in the parent of the comlogs folder
+        parent, tail = os.path.split(logfolder.rstrip(os.sep))
+        if tail == "comlogs":
+            logfolder = parent
 
         # runlog file
         runlogname = "Log-" + logname
@@ -969,7 +967,7 @@ def run_with_log(function, args=None, logfile=None, name=None, prepend=""):
 
         # print session if exists
         if len(split) > 1:
-            print("session: %s\n" % split[1])
+            lf.write("session: %s\n" % split[1])
 
         # print command name
         lf.write("qunex %s \\\n" % split[0])
@@ -1271,7 +1269,11 @@ def close_log_file(logfile=None, logname=None, status="done"):
 
     Closes the logfile and swaps the 'tmp_', 'done_', 'error_', 'incomplete_' at
     the start of the logname to the provided status.
+
+    Returns the path of the renamed log file, or None if no logname was given.
     """
+
+    newfile = None
 
     if logfile:
         logfile.close()

--- a/python/qx_utilities/general/process.py
+++ b/python/qx_utilities/general/process.py
@@ -51,6 +51,10 @@ def writelog(item):
     global log list, and the second to the global stati list. It also
     prints the contents to the file specified in the global logname
     variable.
+
+    Returns the (report, status) pair, so callers do not have to split the
+    item a second time - passing an already split report back in would append
+    a spurious "Unknown" status to stati.
     """
     global logname
     global log
@@ -58,9 +62,9 @@ def writelog(item):
     r, status = proc_response(item)
     log.append(r)
     stati.append(status)
-    f = open(logname, "a")
-    print(r, file=f)
-    f.close()
+    with open(logname, "a") as f:
+        print(r, file=f)
+    return r, status
 
 
 def proc_response(r):
@@ -1390,16 +1394,10 @@ def run(qx_command, args):
                 console_log += message
                 print(message)
 
-                # process
-                r, status = proc_response(
-                    pending_actions(sessions, soptions, overwrite, c + 1)
-                )
-
-                # write log
-                writelog(r)
+                # process and write log
+                r, _ = writelog(pending_actions(sessions, soptions, overwrite, c + 1))
                 console_log += r
                 print(r)
-                stati.append(status)
 
             # ------------------------------------------------------------------
             #                                        subject processing commands
@@ -1410,13 +1408,11 @@ def run(qx_command, args):
                     console_log += message
                     print(message)
 
-                    r, status = proc_response(
+                    r, _ = writelog(
                         pending_actions(subject, options, overwrite, c + 1)
                     )
-                    writelog(r)
                     console_log += r
                     print(r)
-                    stati.append(status)
                     c += 1
                     if nprocess and c >= nprocess:
                         break
@@ -1432,13 +1428,11 @@ def run(qx_command, args):
 
                         soptions = update_options(session, options)
 
-                        r, status = proc_response(
+                        r, _ = writelog(
                             pending_actions(session, soptions, overwrite, c + 1)
                         )
-                        writelog(r)
                         console_log += r
                         print(r)
-                        stati.append(status)
                         c += 1
                         if nprocess and c >= nprocess:
                             break
@@ -1485,10 +1479,11 @@ def run(qx_command, args):
                             break
 
             for future in as_completed(futures):
-                result = future.result()
-                writelog(result)
-                console_log += result[0]
-                print(result[0])
+                # result[0] is not the report unless result is a tuple, so take
+                # the report writelog split out rather than indexing the result
+                r, _ = writelog(future.result())
+                console_log += r
+                print(r)
 
         # print(console log)
         # print(consoleLog)

--- a/python/qx_utilities/gmri
+++ b/python/qx_utilities/gmri
@@ -397,9 +397,9 @@ def runCommand(command, args):
             else:
                 result = "completed"
             if targetLog:
-                print("%s %s %s" % (prepend, name, result))
-            else:
                 print("%s %s %s [log: %s]" % (prepend, name, result, targetLog))
+            else:
+                print("%s %s %s" % (prepend, name, result))
         if ok:
             print(f"\n---> Successful completion of task at {datetime.now()}")
 

--- a/python/tests/test_process_writelog.py
+++ b/python/tests/test_process_writelog.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 QuNex development team <https://qunex.yale.edu/>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Tests for the runlog bookkeeping in ``general.process``.
+
+``writelog`` splits a command's return value into the report text and the
+three-field status, and the final report of a run is built from the collected
+stati. Feeding it an already split report added a second, bogus "Unknown"
+status per session, so these pin that one item in equals one status out.
+"""
+
+import pytest
+
+import qx_utilities.general.process as gp
+
+
+@pytest.fixture(autouse=True)
+def clean_globals(tmp_path):
+    """process.py keeps the runlog in module globals; reset them per test."""
+    gp.log = []
+    gp.stati = []
+    gp.logname = str(tmp_path / "Log-test.log")
+    yield
+
+
+def test_writelog_returns_the_split_it_recorded():
+    r, status = gp.writelog(("report text", ("sess-01", "all good", 0)))
+
+    assert r == "report text"
+    assert status == ("sess-01", "all good", 0)
+
+
+def test_one_result_yields_exactly_one_status():
+    gp.writelog(("report text", ("sess-01", "all good", 0)))
+
+    assert gp.stati == [("sess-01", "all good", 0)]
+    assert gp.log == ["report text"]
+
+
+def test_report_is_appended_to_the_runlog_file():
+    gp.writelog(("report text", ("sess-01", "all good", 0)))
+    gp.writelog(("more text", ("sess-02", "all good", 0)))
+
+    with open(gp.logname) as f:
+        assert f.read() == "report text\nmore text\n"
+
+
+def test_a_plain_string_is_still_accepted_as_unknown_status():
+    # unmigrated commands may return a bare report; it must not crash, but it
+    # is what the "Unknown" status is for -- and why writelog must not be
+    # handed a report it has already split
+    r, status = gp.writelog("bare report")
+
+    assert r == "bare report"
+    assert status == ("Unknown", "Unknown", None)


### PR DESCRIPTION
Fixes a set of defects found while reviewing QuNex logging. They are all in the existing log plumbing, independent of each other, and have no dependency on the planned logging overhaul.

general/core.py:
- close_log_file() raised UnboundLocalError instead of returning when called without a logname; its return value was only bound inside the if branch.
- run_with_log() derived the runlog folder with logfolder.replace("comlogs", ""), which rewrites the substring wherever it occurs, so a study path containing "comlogs" anywhere produced a corrupted path with a doubled separator. Only a trailing "comlogs" component is dropped now.
- run_with_log() wrote the session id with print() rather than lf.write(). sys.stdout is already restored at that point, so the session id went to the console and never reached the runlog.
- removed three bare print statements (no call) in the exception handlers.

gmri:
- the final report of a parallel run had its branches inverted: it printed "[log: %s]" only when targetLog was falsy, rendering "[log: None]", and omitted the path in exactly the case where a log existed.

general/process.py:
- serial runs recorded two statuses per session. The code called proc_response() and then passed the already split report into writelog(), which split it again; a plain string has no status, so the "Unknown" fallback was appended alongside the real one. writelog() now returns the (report, status) pair it recorded and the serial call sites use it.
- the parallel branch built the console log from result[0], which is the first character of the report when a command returns a bare string.
- writelog() opens the runlog through a context manager.

tests/test_process_writelog.py pins one result in yielding exactly one status.

CLAUDE.md: the documented flat-import convention no longer exists in the tree
- the command registry moved the package to absolute qx_utilities.* imports and pytest.ini sits at the repository root with pythonpath = python.