### PR TITLE
88 extensions cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 ## 1.5.2
 
 * Fixed a bug in `dwi_probtrackx_dense_gpu` that caused it to crash under certain parameter values.
+* Fixed and improved the handling of QuNex extensions; `build_qx_registry --build_core=no` builds extensions without rewriting the core registry.
 
 ## 1.5.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,16 @@ Quality:
   `pythonpath = python` is set in `pytest.ini` at the repository root. Do not add flat
   imports (`from general import core as gc`); there are none left in the tree.
 - Before deleting a seemingly-unused function, confirm it is not a dynamic/external entrypoint:
-  registered commands (a `.. qx_command:` docstring, called via the registry) and the
-  `@qx_process` extension decorator in `general/extensions.py` (used by out-of-tree extensions
-  loaded via `$QXEXTENSIONSPY`) look unused in-tree but must not be removed.
+  registered commands (a `.. qx_command:` docstring, called via the registry) look unused in-tree
+  but must not be removed. The same goes for `general/extensions.py`, which is the whole of the
+  extension interface: `load_extensions`, `compile_list` and `compile_dict` are called from
+  `general/__init__.py`, `process.py` and `commands_support.py`, and the nine lists and
+  dictionaries they gather are what an out-of-tree extension declares. The `@qx_process`
+  decorator there **declares parameters and does not register a command** — its arguments
+  (`command_type`, `short_name`, `long_name`, `description`) are inert and are kept only so that
+  an extension written against the older decorator still imports. The pre-registry declaration
+  surface beside it — the `commands` dict, the `qx` decorator and `calist`/`salist`/`lalist`/
+  `malist` — was removed once nothing read it.
 
 ## Command logging (runlog vs comlog)
 

--- a/env/qunex_environment.sh
+++ b/env/qunex_environment.sh
@@ -419,8 +419,36 @@ QXEXTENSIONSPY=""
 # -- covert $QUNEXEXTENSIONSFOLDERS from colon separated to space
 QUNEXEXTENSIONSFOLDERS=`echo $QUNEXEXTENSIONSFOLDERS | tr ':' ' '`
 
+# -- QUNEXEXTENSIONFOLDERS is the spelling the python half used to read on its
+#    own, which left a folder named in only one of them half registered. It is
+#    still accepted so that an installation setting it keeps working
+QUNEXEXTENSIONFOLDERS=`echo $QUNEXEXTENSIONFOLDERS | tr ':' ' '`
+if [ -n "$QUNEXEXTENSIONFOLDERS" ]
+then
+    echo "WARNING: QUNEXEXTENSIONFOLDERS is deprecated and will be removed in a future release. Please name the extension folders in QUNEXEXTENSIONSFOLDERS instead." >&2
+fi
+
+# -- the folders named in the environment, de-duplicated so that one named in
+#    both variables -- which is how an installation migrates from the old
+#    spelling -- is registered once and not twice. A folder somebody named and
+#    QuNex can not use is worth a line; the two fixed roots are absent on most
+#    installations and are passed over in silence
+QUNEXEXTENSIONSNAMED=""
+for extensions_folder in $QUNEXEXTENSIONSFOLDERS $QUNEXEXTENSIONFOLDERS
+do
+    case " $QUNEXEXTENSIONSNAMED " in *" $extensions_folder "*) continue ;; esac
+
+    if [ ! -d "$extensions_folder" ]
+    then
+        echo "WARNING: extensions folder '$extensions_folder' does not exist or is not a folder, skipping it." >&2
+        continue
+    fi
+
+    QUNEXEXTENSIONSNAMED="$QUNEXEXTENSIONSNAMED $extensions_folder"
+done
+
 # -- loop through plugin folders
-for extensions_folder in "$QUNEXPATH/qx_extensions" "$TOOLS/qx_extensions" $QUNEXEXTENSIONSFOLDERS
+for extensions_folder in "$QUNEXPATH/qx_extensions" "$TOOLS/qx_extensions" $QUNEXEXTENSIONSNAMED
 do
     # -- identify extensions and loop through them
     for extension in `ls -d $extensions_folder/qx_* 2> /dev/null`

--- a/env/qunex_environment.sh
+++ b/env/qunex_environment.sh
@@ -486,8 +486,11 @@ do
             echo "    ... added $extensions_folder/$extension_name/bin to PATH"
         fi
 
-        # -- Add python folder to QXEXTENSIONSPY
-        if [ -e "$extensions_folder/$extension_name/python/qx_modules" ]
+        # -- Add python folder to QXEXTENSIONSPY. On the folder and not on the
+        #    qx_modules file inside it: a python command is imported by a path
+        #    dotted relative to this folder, so an extension without the file
+        #    had commands that were listed and dispatched and then failed
+        if [ -d "$extensions_folder/$extension_name/python" ]
         then
             QXEXTENSIONSPY="$extensions_folder/$extension_name/python":$QXEXTENSIONSPY
             echo "    ... added $extensions_folder/$extension_name/python to QXEXTENSIONSPY"

--- a/python/qx_extension_paths.py
+++ b/python/qx_extension_paths.py
@@ -1,0 +1,131 @@
+# encoding: utf-8
+
+# SPDX-FileCopyrightText: 2026 QuNex development team <https://qunex.yale.edu/>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Where QuNex looks for extensions.
+
+A leaf: it imports nothing from QuNex, and both halves that need the answer
+import it. `qx_registry` asks so that it can find each extension's registry;
+`general/extensions.py` asks so that it can put each extension's python folder
+on `sys.path`. The second of those runs while `qx_registry` is still being
+imported -- `general/__init__.py` loads the extensions as it is read -- so the
+two cannot ask each other, and neither should hold its own copy of the answer:
+one variable spelled two ways is the defect this file exists to prevent.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import List
+
+
+# The variable naming the folders QuNex searches for extensions. It was spelled
+# with the second S in the shell and without it in python, so a root named in
+# only one of them was half integrated -- it got PATH, MATLABPATH and
+# QXEXTENSIONSPY but no registry, or a registry whose commands could not import.
+# The shell's spelling is canonical; the other is still read, with a notice, for
+# installations that set it.
+EXTENSION_FOLDERS_ENV = "QUNEXEXTENSIONSFOLDERS"
+EXTENSION_FOLDERS_ENV_DEPRECATED = "QUNEXEXTENSIONFOLDERS"
+
+_warned: set = set()
+
+
+def _warn(message: str) -> None:
+    """
+    One warning line, once per process, on stderr.
+
+    Never on stdout: `bin/qunex.sh` reads `gmri -available` as its routing table,
+    so anything printed there is taken for a command name.
+    """
+    if message not in _warned:
+        _warned.add(message)
+        print(f"WARNING: {message}", file=sys.stderr)
+
+
+def _split_env_path_list(value: str) -> List[str]:
+    value = (value or "").strip()
+    if not value:
+        return []
+    value = value.replace(";", ":")
+    return [p.strip() for p in value.split(":") if p.strip()]
+
+
+def extension_search_roots() -> List[Path]:
+    roots: List[Path] = []
+
+    qunexpath = os.environ.get("QUNEXPATH", "").strip()
+    if qunexpath:
+        roots.append(Path(qunexpath) / "qx_extensions")
+
+    tools = os.environ.get("TOOLS", "").strip()
+    if tools:
+        roots.append(Path(tools) / "qx_extensions")
+
+    named = _split_env_path_list(os.environ.get(EXTENSION_FOLDERS_ENV, ""))
+    deprecated = _split_env_path_list(os.environ.get(EXTENSION_FOLDERS_ENV_DEPRECATED, ""))
+
+    if deprecated:
+        _warn(
+            f"{EXTENSION_FOLDERS_ENV_DEPRECATED} is deprecated and will be removed in a "
+            f"future release. Please name the extension folders in "
+            f"{EXTENSION_FOLDERS_ENV} instead."
+        )
+
+    # a folder somebody named and QuNex cannot use is worth a line: the two fixed
+    # roots above are absent on most installations and are passed over in silence
+    for folder in named + deprecated:
+        path = Path(folder).expanduser()
+        if not path.is_dir():
+            _warn(f"extensions folder '{folder}' does not exist or is not a folder, skipping it.")
+            continue
+        roots.append(path)
+
+    # de-dup preserving order
+    seen = set()
+    uniq: List[Path] = []
+    for r in roots:
+        rr = r.expanduser()
+        try:
+            rr = rr.resolve()
+        except Exception:
+            pass
+        s = str(rr)
+        if s not in seen:
+            seen.add(s)
+            uniq.append(rr)
+    return uniq
+
+
+def extension_python_folders() -> List[str]:
+    """
+    The python folder of every extension QuNex can see.
+
+    Read from two places, and both are needed. `QXEXTENSIONSPY` is what the
+    environment script exports, and it names an extension that was in place when
+    the environment was set up. The search roots are read here as well because
+    that environment cannot always be refreshed: inside a container it is sourced
+    once and every later source returns immediately, so an extension installed
+    after the container started would otherwise never reach the path, and its
+    commands would be listed and dispatched and then fail to import.
+    """
+    folders = [e.strip() for e in os.environ.get("QXEXTENSIONSPY", "").split(":") if e.strip()]
+
+    for root in extension_search_roots():
+        if not root.is_dir():
+            continue
+        for extension in sorted(root.iterdir()):
+            if not (extension.is_dir() and extension.name.startswith("qx_")):
+                continue
+            python_folder = extension / "python"
+            if python_folder.is_dir():
+                folders.append(str(python_folder))
+
+    # de-duplicate, keeping the order the folders were found in
+    seen = set()
+    return [f for f in folders if not (f in seen or seen.add(f))]

--- a/python/qx_extension_paths.py
+++ b/python/qx_extension_paths.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import List
+from typing import Dict, List
 
 
 # The variable naming the folders QuNex searches for extensions. It was spelled
@@ -102,6 +102,26 @@ def extension_search_roots() -> List[Path]:
     return uniq
 
 
+def extension_folders() -> List[Path]:
+    """
+    Every extension QuNex can see, as its own `qx_<name>` folder.
+
+    An extension found under more than one root is taken from the last of them,
+    which is how the registry resolves it too -- so the code that runs and the
+    folders set up for it are always the same copy.
+    """
+    found: Dict[str, Path] = {}
+
+    for root in extension_search_roots():
+        if not root.is_dir():
+            continue
+        for extension in sorted(root.iterdir()):
+            if extension.is_dir() and extension.name.startswith("qx_"):
+                found[extension.name] = extension
+
+    return [found[name] for name in sorted(found)]
+
+
 def extension_python_folders() -> List[str]:
     """
     The python folder of every extension QuNex can see.
@@ -116,15 +136,10 @@ def extension_python_folders() -> List[str]:
     """
     folders = [e.strip() for e in os.environ.get("QXEXTENSIONSPY", "").split(":") if e.strip()]
 
-    for root in extension_search_roots():
-        if not root.is_dir():
-            continue
-        for extension in sorted(root.iterdir()):
-            if not (extension.is_dir() and extension.name.startswith("qx_")):
-                continue
-            python_folder = extension / "python"
-            if python_folder.is_dir():
-                folders.append(str(python_folder))
+    for extension in extension_folders():
+        python_folder = extension / "python"
+        if python_folder.is_dir():
+            folders.append(str(python_folder))
 
     # de-duplicate, keeping the order the folders were found in
     seen = set()

--- a/python/qx_registry.py
+++ b/python/qx_registry.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,6 +48,13 @@ class CommandInfo:
     # optional `logging:` from the qx_command block: none|comlog|runlog|both.
     # None means the command states nothing and the settings files decide.
     logging: Optional[str] = None
+    # the folder the registry carrying this command was loaded from: the
+    # extension folder for an extension command, $QUNEXPATH for a core one.
+    # Filled in at load and never written to the yaml, so an extension that is
+    # moved or installed elsewhere still resolves. `run_bash` finds the script
+    # under it; python and matlab commands are found through `sys.path` and
+    # `MATLABPATH` instead.
+    root: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -80,8 +88,9 @@ def _now_utc_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def registry_from_obj(obj: Dict[str, Any]) -> Registry:
+def registry_from_obj(obj: Dict[str, Any], root: Optional[str | Path] = None) -> Registry:
     cmds: List[CommandInfo] = []
+    root = str(root) if root is not None else None
     source_id = (obj.get("source") or {}).get("id", "unknown")
     generated_at = obj.get("generated_at") or ""
     version = int(obj.get("version") or 1)
@@ -112,6 +121,7 @@ def registry_from_obj(obj: Dict[str, Any]) -> Registry:
                 returns=load_args(c.get("returns") or []),
                 origin=c.get("origin", source_id),
                 logging=c.get("logging"),
+                root=root,
             )
         )
 
@@ -134,7 +144,11 @@ def read_registry_file(path: Path) -> Dict[str, Any]:
 
 
 def load_registry_yaml(path: str | Path) -> Registry:
-    return registry_from_obj(read_registry_file(Path(path)))
+    # the registry file sits at the root of what it describes -- <ext>/qx_commands.yaml
+    # for an extension, $QUNEXPATH/qx_commands.yaml for core -- so its folder is the
+    # root every command in it is resolved against
+    path = Path(path)
+    return registry_from_obj(read_registry_file(path), root=path.parent)
 
 
 def merge_registries(
@@ -183,6 +197,29 @@ def load_python_callable(command: CommandInfo):
     return getattr(mod, fn_name)
 
 
+# The variable naming the folders QuNex searches for extensions. It was spelled
+# with the second S in the shell and without it here, so a root named in only one
+# of them was half integrated -- it got PATH, MATLABPATH and QXEXTENSIONSPY but no
+# registry, or a registry whose commands could not import. The shell's spelling is
+# canonical; the other is still read, with a notice, for installations that set it.
+EXTENSION_FOLDERS_ENV = "QUNEXEXTENSIONSFOLDERS"
+EXTENSION_FOLDERS_ENV_DEPRECATED = "QUNEXEXTENSIONFOLDERS"
+
+_warned: set = set()
+
+
+def _warn(message: str) -> None:
+    """
+    One warning line, once per process, on stderr.
+
+    Never on stdout: `bin/qunex.sh` reads `gmri -available` as its routing table,
+    so anything printed there is taken for a command name.
+    """
+    if message not in _warned:
+        _warned.add(message)
+        print(f"WARNING: {message}", file=sys.stderr)
+
+
 def _split_env_path_list(value: str) -> List[str]:
     value = (value or "").strip()
     if not value:
@@ -202,9 +239,24 @@ def extension_search_roots() -> List[Path]:
     if tools:
         roots.append(Path(tools) / "qx_extensions")
 
-    extra = os.environ.get("QUNEXEXTENSIONFOLDERS", "").strip()
-    for folder in _split_env_path_list(extra):
-        roots.append(Path(folder))
+    named = _split_env_path_list(os.environ.get(EXTENSION_FOLDERS_ENV, ""))
+    deprecated = _split_env_path_list(os.environ.get(EXTENSION_FOLDERS_ENV_DEPRECATED, ""))
+
+    if deprecated:
+        _warn(
+            f"{EXTENSION_FOLDERS_ENV_DEPRECATED} is deprecated and will be removed in a "
+            f"future release. Please name the extension folders in "
+            f"{EXTENSION_FOLDERS_ENV} instead."
+        )
+
+    # a folder somebody named and QuNex cannot use is worth a line: the two fixed
+    # roots below are absent on most installations and are passed over in silence
+    for folder in named + deprecated:
+        path = Path(folder).expanduser()
+        if not path.is_dir():
+            _warn(f"extensions folder '{folder}' does not exist or is not a folder, skipping it.")
+            continue
+        roots.append(path)
 
     # de-dup preserving order
     seen = set()

--- a/python/qx_registry.py
+++ b/python/qx_registry.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import os
-import sys
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,6 +17,18 @@ try:
     from qx_utilities.general import exceptions as ge
 except ModuleNotFoundError:
     from general import exceptions as ge
+# where extensions live is answered in one place, by a module that imports
+# nothing from QuNex -- `general/extensions.py` needs the same answer while this
+# module is still being imported, so it cannot ask this one. Re-exported here
+# because this is where callers have always found it
+from qx_extension_paths import (  # noqa: F401
+    EXTENSION_FOLDERS_ENV,
+    EXTENSION_FOLDERS_ENV_DEPRECATED,
+    _split_env_path_list,
+    _warn,
+    _warned,
+    extension_search_roots,
+)
 
 
 DEFAULT_CORE_REGISTRY_BASENAME = "qx_commands.yaml"
@@ -206,83 +217,6 @@ def load_python_callable(command: CommandInfo):
     import importlib
     mod = importlib.import_module(mod_path)
     return getattr(mod, fn_name)
-
-
-# The variable naming the folders QuNex searches for extensions. It was spelled
-# with the second S in the shell and without it here, so a root named in only one
-# of them was half integrated -- it got PATH, MATLABPATH and QXEXTENSIONSPY but no
-# registry, or a registry whose commands could not import. The shell's spelling is
-# canonical; the other is still read, with a notice, for installations that set it.
-EXTENSION_FOLDERS_ENV = "QUNEXEXTENSIONSFOLDERS"
-EXTENSION_FOLDERS_ENV_DEPRECATED = "QUNEXEXTENSIONFOLDERS"
-
-_warned: set = set()
-
-
-def _warn(message: str) -> None:
-    """
-    One warning line, once per process, on stderr.
-
-    Never on stdout: `bin/qunex.sh` reads `gmri -available` as its routing table,
-    so anything printed there is taken for a command name.
-    """
-    if message not in _warned:
-        _warned.add(message)
-        print(f"WARNING: {message}", file=sys.stderr)
-
-
-def _split_env_path_list(value: str) -> List[str]:
-    value = (value or "").strip()
-    if not value:
-        return []
-    value = value.replace(";", ":")
-    return [p.strip() for p in value.split(":") if p.strip()]
-
-
-def extension_search_roots() -> List[Path]:
-    roots: List[Path] = []
-
-    qunexpath = os.environ.get("QUNEXPATH", "").strip()
-    if qunexpath:
-        roots.append(Path(qunexpath) / "qx_extensions")
-
-    tools = os.environ.get("TOOLS", "").strip()
-    if tools:
-        roots.append(Path(tools) / "qx_extensions")
-
-    named = _split_env_path_list(os.environ.get(EXTENSION_FOLDERS_ENV, ""))
-    deprecated = _split_env_path_list(os.environ.get(EXTENSION_FOLDERS_ENV_DEPRECATED, ""))
-
-    if deprecated:
-        _warn(
-            f"{EXTENSION_FOLDERS_ENV_DEPRECATED} is deprecated and will be removed in a "
-            f"future release. Please name the extension folders in "
-            f"{EXTENSION_FOLDERS_ENV} instead."
-        )
-
-    # a folder somebody named and QuNex cannot use is worth a line: the two fixed
-    # roots below are absent on most installations and are passed over in silence
-    for folder in named + deprecated:
-        path = Path(folder).expanduser()
-        if not path.is_dir():
-            _warn(f"extensions folder '{folder}' does not exist or is not a folder, skipping it.")
-            continue
-        roots.append(path)
-
-    # de-dup preserving order
-    seen = set()
-    uniq: List[Path] = []
-    for r in roots:
-        rr = r.expanduser()
-        try:
-            rr = rr.resolve()
-        except Exception:
-            pass
-        s = str(rr)
-        if s not in seen:
-            seen.add(s)
-            uniq.append(rr)
-    return uniq
 
 
 def discover_extension_registries(

--- a/python/qx_registry.py
+++ b/python/qx_registry.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import os
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -48,6 +48,10 @@ class CommandInfo:
     # optional `logging:` from the qx_command block: none|comlog|runlog|both.
     # None means the command states nothing and the settings files decide.
     logging: Optional[str] = None
+    # what this command displaced when the registries were merged, when it
+    # displaced anything: the origin of the record it replaced. Set at merge,
+    # so that a run can say it is not running the command it appears to be
+    overrides: Optional[str] = None
     # the folder the registry carrying this command was loaded from: the
     # extension folder for an extension command, $QUNEXPATH for a core one.
     # Filled in at load and never written to the yaml, so an extension that is
@@ -159,6 +163,13 @@ def merge_registries(
     by_name: Dict[str, CommandInfo] = {c.name: c for c in base.commands}
     for reg in overlays:
         for c in reg.commands:
+            # a command standing in for one already known keeps a note of what
+            # it displaced. The record the merge keeps is otherwise the only
+            # trace: the call echo, the parameter table and the runlog all name
+            # the command, which is the same name either way
+            displaced = by_name.get(c.name)
+            if displaced is not None and displaced.origin != c.origin:
+                c = replace(c, overrides=displaced.origin)
             by_name[c.name] = c
 
     merged_cmds = list(by_name.values())
@@ -430,15 +441,28 @@ class CommandRegistry:
 
     def gmri_commands(self) -> List[str]:
         """
-        The commands `gmri` runs, which is every command it knows of but one.
+        The commands `gmri` runs, which is every command it knows of but one,
+        each under its name and under every alias it declares.
 
         `bin/qunex.sh` hands over everything this reports and handles the rest
         itself, so this function is the routing: the wrappers for the bash
         commands are still in that file and are simply no longer reached.
         `run_turnkey` is the exception, and keeps its old path until it is
         retired.
+
+        The aliases are here because this is a routing table rather than a
+        listing. Reporting names alone meant `bin/qunex.sh` did not recognise
+        an alias and answered "Requested command is not supported", while
+        `gmri` -- which resolves through the registry's token map -- ran it.
+        The tokens are unique across the merged registry by construction, so
+        nothing here can shadow a command's name.
         """
-        return [c.name for c in self.iter() if c.name not in ("run_turnkey",)]
+        return [
+            token
+            for c in self.iter()
+            if c.name not in ("run_turnkey",)
+            for token in (c.name,) + c.aliases
+        ]
 
     def to_qunex_list(self) -> List[Tuple[str, str, Optional[str], str]]:
         """

--- a/python/qx_registry_build.py
+++ b/python/qx_registry_build.py
@@ -21,9 +21,11 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple
 try:
     from qx_utilities.general import exceptions as ge
     from qx_utilities.general.log import LOGGING_MODES
+    from qx_utilities.general.parsing import flag
 except ModuleNotFoundError:
     from general import exceptions as ge
     from general.log import LOGGING_MODES
+    from general.parsing import flag
 from qx_registry import (
     ArgInfo,
     CommandInfo,
@@ -32,6 +34,7 @@ from qx_registry import (
     DEFAULT_EXTENSION_REGISTRY_FILENAME,
     _now_utc_iso,
     registry_from_obj,
+    load_registry_yaml,
     extension_search_roots,
 )
 
@@ -973,6 +976,7 @@ def build_qx_registry(
     *,
     core_python_root: Optional[str | Path] = None,
     core_registry_yaml: Optional[str | Path] = None,
+    build_core: bool = True,
     build_extensions: bool = True,
     extension_registry_filename: str = DEFAULT_EXTENSION_REGISTRY_FILENAME,
     extension_python_subdir: str = "python",
@@ -985,8 +989,43 @@ def build_qx_registry(
     Build core registry at $QUNEXPATH/qx_commands.yaml (python + matlab + bash for core),
     and build each extension registry at <ext_root>/qx_commands.yaml (python + matlab + bash if present).
 
+    An extension is found under $QUNEXPATH/qx_extensions, under $TOOLS/qx_extensions,
+    or under a folder named in $QUNEXEXTENSIONSFOLDERS. Its registry is written beside
+    its code and is what makes its commands visible to QuNex, so an extension has to be
+    built once before it can be used.
+
     ..  qx_command:
         type: utility
+
+    Parameters:
+        --core_python_root (str, default ''):
+            The folder to index the core python commands from. Defaults to
+            $QUNEXPATH/python.
+
+        --core_registry_yaml (str, default ''):
+            The file to write the core registry to. Defaults to
+            $QUNEXPATH/qx_commands.yaml.
+
+        --build_core (str, default 'yes'):
+            Whether to build the core registry. Set to 'no' to leave the core
+            registry alone and build only the extensions, which is what an
+            extension author wants and what a read-only installation requires.
+
+        --build_extensions (str, default 'yes'):
+            Whether to build the registry of every extension found. Set to 'no'
+            to build only core.
+
+        --extension_registry_filename (str, default 'qx_commands.yaml'):
+            The name of the registry file written inside each extension.
+
+        --extension_python_subdir (str, default 'python'):
+            The folder inside an extension holding its python commands.
+
+        --extension_matlab_subdir (str, default 'matlab'):
+            The folder inside an extension holding its MATLAB commands.
+
+        --extension_bash_subdir (str, default 'bash'):
+            The folder inside an extension holding its bash commands.
 
     Returns:
         --registry (tuple):
@@ -994,6 +1033,11 @@ def build_qx_registry(
             built_extensions = [(extension_id, registry_yaml_path), ...]
     """
     qunex_root = _get_qunexpath()
+
+    # both arrive as strings when they come from the command line, where
+    # `--build_core=no` has to mean no rather than a non-empty string
+    build_core = flag(build_core)
+    build_extensions = flag(build_extensions)
 
     if core_python_root is None:
         core_python_root = qunex_root / "python"
@@ -1003,25 +1047,40 @@ def build_qx_registry(
         core_registry_yaml = qunex_root / DEFAULT_CORE_REGISTRY_BASENAME
     core_registry_yaml = Path(core_registry_yaml).resolve()
 
-    if not core_python_root.exists():
-        raise ge.CommandFailed('build_qx_registry', f"Core python root not found: {core_python_root}")
+    if build_core:
+        if not core_python_root.exists():
+            raise ge.CommandFailed('build_qx_registry', f"Core python root not found: {core_python_root}")
 
-    # Core: python
-    print(f"--> Building core python command registry from {core_python_root}")
-    core_cmds = index_python_commands(core_python_root, source_id="core")
+        # Core: python
+        print(f"--> Building core python command registry from {core_python_root}")
+        core_cmds = index_python_commands(core_python_root, source_id="core")
 
-    # Core Matlab
-    # if DEBUG: print(f"--> Checking for core matlab commands in {qunex_root / 'matlab'}")
-    matlab_root = qunex_root / "matlab"
-    if matlab_root.exists():
-        core_cmds.extend( index_matlab_commands(matlab_root, source_id="core"))
+        # Core Matlab
+        # if DEBUG: print(f"--> Checking for core matlab commands in {qunex_root / 'matlab'}")
+        matlab_root = qunex_root / "matlab"
+        if matlab_root.exists():
+            core_cmds.extend( index_matlab_commands(matlab_root, source_id="core"))
 
-    # Core Bash
-    bash_root = qunex_root / "bash"
-    if bash_root.exists():
-        core_cmds.extend(index_bash_commands(bash_root, source_id="core"))
+        # Core Bash
+        bash_root = qunex_root / "bash"
+        if bash_root.exists():
+            core_cmds.extend(index_bash_commands(bash_root, source_id="core"))
 
-    core_reg = build_registry_yaml(core_cmds, out=core_registry_yaml, source_id="core")
+        core_reg = build_registry_yaml(core_cmds, out=core_registry_yaml, source_id="core")
+
+    else:
+        # left as it stands, and read back so that the return says what QuNex
+        # will actually run. Building an extension used to rewrite the core
+        # registry as a side effect, which an extension author does not want
+        # and a read-only installation does not allow
+        if not core_registry_yaml.exists():
+            raise ge.CommandFailed(
+                'build_qx_registry',
+                f"Core registry not found: {core_registry_yaml}",
+                "It has to be built once before an extension can be built on its own.",
+            )
+        print(f"--> Leaving the core command registry as it is: {core_registry_yaml}")
+        core_reg = load_registry_yaml(core_registry_yaml)
 
     built_exts: Dict[str, Path] = {}
 
@@ -1064,6 +1123,8 @@ def build_qx_registry(
 
     print("\n----------------------------------------------------------------\nRegistry built!")
 
+    if not built:
+        print("\n--> No extension registries were built: no extension was found with commands in it.")
     if built:
         print(f"\n--> In addition to core, built {len(built)} extension registries:")
         for ext_id, path in built:

--- a/python/qx_utilities/general/commands_support.py
+++ b/python/qx_utilities/general/commands_support.py
@@ -794,6 +794,39 @@ def select_parameters(options, sources, qx_command):
     return accepted, dropped
 
 
+def report_origin(qx_command):
+    """
+    ``report_origin(qx_command)``
+
+    Where the command being run comes from, when that is not the core suite.
+
+    A command an extension provides is otherwise indistinguishable in the
+    run's own record from a core one -- the call echo, the parameter table
+    and the runlog all name the command, and an extension command standing
+    in for a core command of the same name has the same name. A study that
+    behaves differently from another then has nothing in its logs to say why.
+
+    Parameters:
+        --qx_command    The registry entry of the command to be run.
+
+    Returns:
+        The line to head the banner with, or an empty string for a core
+        command.
+    """
+    origin = getattr(qx_command, "origin", None) or "core"
+    if origin == "core":
+        return ""
+
+    extension = origin.split(":", 1)[1] if ":" in origin else origin
+    note = "\n---> Command %s is provided by extension %s" % (qx_command.name, extension)
+
+    replaced = getattr(qx_command, "overrides", None)
+    if replaced:
+        note += ", replacing the %s command of the same name" % replaced
+
+    return note + "\n"
+
+
 def report_parameters(qx_command, options, sources, session=None):
     """
     ``report_parameters(qx_command, options, sources, session=None)``
@@ -831,7 +864,10 @@ def report_parameters(qx_command, options, sources, session=None):
 
     rows = [(k, str(options[k]), sources.get(k, "default")) for k in reported]
 
-    title = "\n---> Parameters for %s%s\n\n" % (
+    title = "%s\n---> Parameters for %s%s\n\n" % (
+        # only once per run: the per session tier reports under a run that has
+        # already said where the command comes from
+        "" if session else report_origin(qx_command),
         qx_command.name,
         " on session %s" % session["id"] if session else "",
     )

--- a/python/qx_utilities/general/extensions.py
+++ b/python/qx_utilities/general/extensions.py
@@ -25,7 +25,7 @@ import sys
 import importlib
 from inspect import signature, Parameter
 
-from qx_extension_paths import extension_python_folders
+from qx_extension_paths import extension_folders, extension_python_folders
 
 
 module_names = []
@@ -34,8 +34,48 @@ modules      = {}
 arglist = []
 
 
+def register_extension_paths():
+    """
+    Names each extension's folders in this process's environment, and puts its
+    `bin` folder on `PATH`.
+
+    The environment script does the same when it is sourced, and that is enough
+    for an extension that was in place at the time. It is not enough in general:
+    inside a container the script is sourced once, when the container starts,
+    and every later source returns immediately, so an extension installed
+    afterwards had a `bin` folder nothing could call and `<EXT>PATH`,
+    `<EXT>LIB` and `<EXT>BIN` that nothing set.
+
+    Note the reach: this is the environment of the QuNex process and of
+    everything it starts -- a bash command, a MATLAB call, a subprocess an
+    extension's own python code spawns. It is not the environment of the shell
+    QuNex was called from, which no process can change from the inside.
+    """
+    for extension in extension_folders():
+
+        # the name the shell exports under: the folder name, upper-cased with
+        # the underscores taken out, so `qx_example` gives `QXEXAMPLE`
+        name = extension.name.replace('_', '').upper()
+
+        os.environ[f'{name}PATH'] = str(extension)
+
+        lib = extension / 'lib'
+        if lib.is_dir():
+            os.environ[f'{name}LIB'] = str(lib)
+
+        binaries = extension / 'bin'
+        if binaries.is_dir():
+            os.environ[f'{name}BIN'] = str(binaries)
+
+            path = os.environ.get('PATH', '')
+            if str(binaries) not in path.split(os.pathsep):
+                os.environ['PATH'] = os.pathsep.join([str(binaries), path]) if path else str(binaries)
+
+
 # -- process extensions
 def load_extensions():
+    register_extension_paths()
+
     for extensions_path in extension_python_folders():
 
         # -- append the extension python folder to the path. Done whether or

--- a/python/qx_utilities/general/extensions.py
+++ b/python/qx_utilities/general/extensions.py
@@ -25,6 +25,8 @@ import sys
 import importlib
 from inspect import signature, Parameter
 
+from qx_extension_paths import extension_python_folders
+
 
 module_names = []
 modules      = {}
@@ -34,38 +36,34 @@ arglist = []
 
 # -- process extensions
 def load_extensions():
-    if "QXEXTENSIONSPY" in os.environ:
-        #print('=> processing extensions')
-        extensions_paths = [e.strip() for e in os.environ['QXEXTENSIONSPY'].split(':') if e]
+    for extensions_path in extension_python_folders():
 
-        # -- loop through the extension python folders
-        for extensions_path in extensions_paths:
-
-            # -- append the extension python folder to the path. Done whether or
-            #    not the extension has a qx_modules file: a command's registry
-            #    path is dotted relative to this folder and nothing else ever
-            #    adds it, so gating this on the file left an extension whose
-            #    commands were listed and dispatched and then failed to import
+        # -- append the extension python folder to the path. Done whether or
+        #    not the extension has a qx_modules file: a command's registry
+        #    path is dotted relative to this folder and nothing else ever
+        #    adds it, so gating this on the file left an extension whose
+        #    commands were listed and dispatched and then failed to import
+        if extensions_path not in sys.path:
             sys.path.append(extensions_path)
 
-            # -- read the module names. The file is optional and says which
-            #    modules to import eagerly -- the ones declaring parameters,
-            #    flags or deprecations -- not which modules hold commands
-            modules_file = os.path.join(extensions_path, 'qx_modules')
-            if not os.path.exists(modules_file):
-                continue
+        # -- read the module names. The file is optional and says which
+        #    modules to import eagerly -- the ones declaring parameters,
+        #    flags or deprecations -- not which modules hold commands
+        modules_file = os.path.join(extensions_path, 'qx_modules')
+        if not os.path.exists(modules_file):
+            continue
 
-            with open(modules_file, 'r') as f:
-                for line in f:
-                    if (len(line.strip()) > 0) and (not line.strip().startswith('#')):
-                        module_name = line.strip()
-                        if os.path.isdir(os.path.join(extensions_path, module_name)):
-                            sys.path.append(os.path.join(extensions_path, module_name))
-                        try:
-                            modules[module_name] = importlib.import_module(module_name)
-                            module_names.append(module_name)
-                        except Exception:
-                            print(f"WARNING: There was an error when trying to import extension module: {extensions_path}/{module_name}!")
+        with open(modules_file, 'r') as f:
+            for line in f:
+                if (len(line.strip()) > 0) and (not line.strip().startswith('#')):
+                    module_name = line.strip()
+                    if os.path.isdir(os.path.join(extensions_path, module_name)):
+                        sys.path.append(os.path.join(extensions_path, module_name))
+                    try:
+                        modules[module_name] = importlib.import_module(module_name)
+                        module_names.append(module_name)
+                    except Exception:
+                        print(f"WARNING: There was an error when trying to import extension module: {extensions_path}/{module_name}!")
 
 
 def compile_list(list_name):

--- a/python/qx_utilities/general/extensions.py
+++ b/python/qx_utilities/general/extensions.py
@@ -1,5 +1,23 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # encoding: utf-8
+
+# SPDX-FileCopyrightText: 2021 QuNex development team <https://qunex.yale.edu/>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+``extensions.py``
+
+Loads the python modules an extension asks QuNex to import, and collects what
+they declare.
+
+A command is *not* declared here. An extension's function is a QuNex command
+because its docstring carries a `.. qx_command:` block and
+`qunex build_qx_registry` indexed it, exactly as a core command is. What this
+file collects is everything an extension states explicitly: the parameters and
+flags its commands take, the deprecations it honours, and the handful of other
+lists and dictionaries `process.py` and `commands_support.py` read.
+"""
 
 import os
 import os.path
@@ -11,12 +29,7 @@ from inspect import signature, Parameter
 module_names = []
 modules      = {}
 
-commands = {}  # legacy: the `qx` decorator populates this; the old `general.commands` reader was retired in favor of qx_registry
 arglist = []
-calist = []
-lalist = []
-malist = []
-salist = []
 
 
 # -- process extensions
@@ -25,32 +38,34 @@ def load_extensions():
         #print('=> processing extensions')
         extensions_paths = [e.strip() for e in os.environ['QXEXTENSIONSPY'].split(':') if e]
 
-        # -- loop through paths and check that we have qx_modules file
+        # -- loop through the extension python folders
         for extensions_path in extensions_paths:
-            if os.path.exists(os.path.join(extensions_path, 'qx_modules')):
 
-                # -- append the module python folder to the path
-                sys.path.append(extensions_path)
+            # -- append the extension python folder to the path. Done whether or
+            #    not the extension has a qx_modules file: a command's registry
+            #    path is dotted relative to this folder and nothing else ever
+            #    adds it, so gating this on the file left an extension whose
+            #    commands were listed and dispatched and then failed to import
+            sys.path.append(extensions_path)
 
-                # -- read the module names
-                with open(os.path.join(extensions_path, 'qx_modules'), 'r') as f:
-                    for line in f:
-                        if (len(line.strip()) > 0) and (not line.strip().startswith('#')):
-                            module_name = line.strip()
-                            if os.path.isdir(os.path.join(extensions_path, module_name)):
-                                sys.path.append(os.path.join(extensions_path, module_name))
-                            try:
-                                modules[module_name] = importlib.import_module(module_name)
-                                module_names.append(module_name)
-                            except Exception:
-                                print(f"WARNING: There was an error when trying to import extension module: {extensions_path}/{module_name}!")
+            # -- read the module names. The file is optional and says which
+            #    modules to import eagerly -- the ones declaring parameters,
+            #    flags or deprecations -- not which modules hold commands
+            modules_file = os.path.join(extensions_path, 'qx_modules')
+            if not os.path.exists(modules_file):
+                continue
 
-        # -- load the modules
-        # if module_names:
-        #     for module_name in module_names:
-        #         print(f'   ... importing module {module_name}')
-        #         if os.path.isdir(os.path.join(extensions_path, module_name))
-        #         modules[module_name] = importlib.import_module(module_name)
+            with open(modules_file, 'r') as f:
+                for line in f:
+                    if (len(line.strip()) > 0) and (not line.strip().startswith('#')):
+                        module_name = line.strip()
+                        if os.path.isdir(os.path.join(extensions_path, module_name)):
+                            sys.path.append(os.path.join(extensions_path, module_name))
+                        try:
+                            modules[module_name] = importlib.import_module(module_name)
+                            module_names.append(module_name)
+                        except Exception:
+                            print(f"WARNING: There was an error when trying to import extension module: {extensions_path}/{module_name}!")
 
 
 def compile_list(list_name):
@@ -77,55 +92,50 @@ def compile_dict(dict_name):
     returns a dictionary compiled across all modules.
     '''
     extensions_dict = {}
-    # print(f'-> extensions_dict {dict_name}')
-    # print(f'   -> modules {module_names}')
     for module_name in module_names:
-        # print(f'... module {module_name}')
         if hasattr(modules[module_name], dict_name):
-            # print(f'... dict {dict_name}')
             if type(getattr(modules[module_name], dict_name)) is dict:
-                # print(f"... adding {getattr(modules[module_name], dict_name)}")
                 extensions_dict.update(getattr(modules[module_name], dict_name))
 
     return extensions_dict
 
 
-def qx(qx_cmd=None):
-    def inner_decorator(f):
-        nonlocal qx_cmd
-        if qx_cmd is None:
-            qx_cmd = f.__name__
-        if qx_cmd not in commands:
-            commands[qx_cmd] = {'com': f, 'args': list(signature(f).parameters.keys())}
-        return f
-    return inner_decorator
-
-
 def qx_process(command_type="parallel", short_name=None, long_name=None, description=None):
+    '''
+    qx_process(command_type="parallel", short_name=None, long_name=None, description=None)
+
+    Declares the parameters of an extension's processing command.
+
+    It does not register a command, and has not since the command registry
+    arrived: a function is a QuNex command because its docstring carries a
+    `.. qx_command:` block and `build_qx_registry` indexed it. What is left is
+    the conversion of the decorated function's keyword arguments into `arglist`
+    entries -- each parameter's default, and the way its value is read -- which
+    is the same job a module level `arglist` does, and which the extension
+    documentation now teaches directly.
+
+    `command_type`, `short_name`, `long_name` and `description` are no longer
+    read. They are still accepted so that an extension written against the
+    older decorator imports rather than failing, and taking the whole module's
+    declarations down with it.
+    '''
 
     def inner_decorator(f):
-        global arglist, calist, lalist, malist, salist
-        nonlocal command_type, short_name, long_name, description
+        global arglist
 
         f_signature = signature(f)
 
         # check arguments
         if (not list(f_signature.parameters.keys())[0] == 'sinfo'):
             first_arg = list(f_signature.parameters.keys())[0]
-            print(f"First argument of QuNex processing command must be 'sinfo', but got {first_arg}. Not registering {f.__name__}")
+            print(f"First argument of QuNex processing command must be 'sinfo', but got {first_arg}. Not declaring the parameters of {f.__name__}")
             return f
         if 'overwrite' not in f_signature.parameters:
-            print('A QuNex extension function must have a keyword argument "overwrite". Not registering {f.__name__}')
+            print(f'A QuNex extension function must have a keyword argument "overwrite". Not declaring the parameters of {f.__name__}')
             return f
         if 'thread' not in f_signature.parameters:
-            print('A QuNex extension function must have a keyword argument "thread". Not registering {f.__name__}')
+            print(f'A QuNex extension function must have a keyword argument "thread". Not declaring the parameters of {f.__name__}')
             return f
-
-        def f_decorated(sinfo, options, overwrite, thread):
-            kwargs = {k: options[k] for k in f_signature.parameters if k not in ['sinfo', 'options', 'overwrite', 'thread']}
-            return f(sinfo, options, overwrite=overwrite, thread=thread, **kwargs)
-
-        f_decorated.__doc__ = f.__doc__
 
         # --- add options to arglist ---
         def _check_default(x):
@@ -140,31 +150,15 @@ def qx_process(command_type="parallel", short_name=None, long_name=None, descrip
             else:
                 return x
 
+        # `options` is the merged options dictionary the command is handed, not
+        # a parameter of its own. It was excluded where these entries used to be
+        # read and not where they are written, which did not show while the
+        # entries were being dropped for having four elements
         arglist += [
             [arg, _check_default(param.default), _check_annotation(param.annotation), ""]
             for arg, param in f_signature.parameters.items()
-            if arg not in ['sinfo', 'overwrite', 'thread']
+            if arg not in ['sinfo', 'options', 'overwrite', 'thread']
         ]
-
-        # --- add function to qunex command list ---
-        if short_name is None:
-            short_name = f.__name__
-        if long_name is None:
-            long_name = f.__name__
-        if description is None:
-            if f.__doc__ is not None:
-                description = f.__doc__.splitlines()[0].strip()
-            else:
-                description = ""
-
-        dict(
-            parallel=calist,
-            single=salist,
-            longitudinal=lalist,
-            multisession=malist,
-        )[command_type].append(
-            [short_name, long_name, f_decorated, description]
-        )
 
         return f
 

--- a/python/qx_utilities/general/matlab.py
+++ b/python/qx_utilities/general/matlab.py
@@ -49,6 +49,46 @@ def help(command):
 #                                                              RUNNING FUNCTIONS
 #
 
+def extension_matlab_folders(qx_command):
+    """
+    The MATLAB folders an extension command needs on `MATLABPATH`: the
+    extension's own `matlab` folder, and whatever its `matlabpaths` file lists
+    beside it.
+
+    The environment script puts these there when it is sourced, and that is
+    enough for an extension that was in place at the time. It is not enough in
+    general: inside a container the environment is sourced once and every later
+    source returns immediately, so an extension installed after the container
+    started would have its command dispatched and then fail to resolve. The
+    registry record says where the command lives, which is the same answer
+    without the environment.
+
+    Empty for a core command, whose folders the environment already carries.
+    """
+    if getattr(qx_command, 'origin', 'core') == 'core':
+        return []
+
+    root = getattr(qx_command, 'root', None)
+    if not root:
+        return []
+
+    matlab_root = os.path.join(root, 'matlab')
+    if not os.path.isdir(matlab_root):
+        return []
+
+    folders = [matlab_root]
+
+    listed = os.path.join(matlab_root, 'matlabpaths')
+    if os.path.exists(listed):
+        with open(listed, 'r') as f:
+            for line in f:
+                folder = os.path.join(matlab_root, line.strip())
+                if line.strip() and os.path.isdir(folder):
+                    folders.append(folder)
+
+    return folders
+
+
 def run(qx_command, args, run=None):
     """
     Runs a matlab command, keeping its output in a comlog of its own.
@@ -93,6 +133,13 @@ def run(qx_command, args, run=None):
             if not argtype:
                 print(f"    ... WARNING: argument '{arg.name}' of {qx_command.name} has no documented type; passing value as-is")
             arglist.append("[]" if value == '' else "%s" % (value))
+
+    # -- make sure the extension's own matlab code can be found
+
+    for folder in extension_matlab_folders(qx_command):
+        current = os.environ.get('MATLABPATH', '')
+        if folder not in current.split(':'):
+            os.environ['MATLABPATH'] = ':'.join([folder, current]) if current else folder
 
     # -- compose command string
 

--- a/python/qx_utilities/general/process.py
+++ b/python/qx_utilities/general/process.py
@@ -20,6 +20,7 @@ None of the code is run directly from the terminal interface.
 # imports
 import os
 import os.path
+import sys
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime
 
@@ -41,7 +42,7 @@ from qx_utilities.general.parsing import true_or_false as torf
 # -----------------------------------------------------------------------
 #                                   list of parameters and default values
 #  A list of possible parameters / arguments follows. Every parameter is
-#  specified as a list of four values:
+#  specified as a list of three values, optionally followed by a fourth:
 #
 #  1/ the name of the parameter
 #     ... This is the name that will be used to identify the parameter in
@@ -59,7 +60,13 @@ from qx_utilities.general.parsing import true_or_false as torf
 #         float (convert the value to float), torf (check if the string
 #         denotes a "true" value and return a bulean representation). Any
 #         other function that takes string as an input and does not
-#         require any other parameters is valid.
+#         require any other parameters is valid. An entry whose convert
+#         function is not callable is reported and left unconverted, so
+#         that one bad declaration in an extension does not fail every
+#         command.
+#  4/ the description (optional)
+#     ... A short description of the parameter. Not read by QuNex; it is
+#         accepted so that a declaration can carry its own documentation.
 #
 #  Parameters are divided into sections. Every section starts with a list
 #  of a single string element in the form "# ---- <section title>".
@@ -1163,8 +1170,11 @@ def merge_options(command, args, header=None):
             options[key] = value
             sources[key] = source
 
-    # the defaults
-    take("default", [(line[0], line[1]) for line in arglist if len(line) == 3])
+    # the defaults. Three elements are [name, default, converter]; a fourth,
+    # a description, is accepted and ignored -- it is the form the extension
+    # documentation teaches, and reading only three-element entries left a
+    # parameter declared that way with no default and no type at all
+    take("default", [(line[0], line[1]) for line in arglist if len(line) >= 3])
 
     # the batch file header
     if header:
@@ -1200,18 +1210,35 @@ def merge_options(command, args, header=None):
 
     # recode as last step before options are used
     for line in arglist:
-        if len(line) == 3:
-            try:
-                options[line[0]] = line[2](options[line[0]])
-            except Exception:
-                raise ge.CommandError(
-                    command,
-                    "Invalid parameter value!",
-                    "Parameter `%s` is specified but is set to an invalid value:"
-                    % (line[0]),
-                    "---> %s=%s" % (line[0], str(options[line[0]])),
-                    "Please check acceptable inputs for %s!" % (line[0]),
-                )
+        if len(line) < 3:
+            continue
+
+        # this loop runs over the whole arglist on every invocation of every
+        # command, so an entry whose third element is not a converter at all
+        # would fail the suite rather than the declaration. An extension can
+        # produce one: a parameter annotation reaches here as the converter,
+        # and `Optional[str]` or any annotation under
+        # `from __future__ import annotations` is not callable
+        if not callable(line[2]):
+            print(
+                "WARNING: parameter `%s` declares `%s` as its convert function, "
+                "which can not be called. The parameter keeps the value it was "
+                "given, unconverted." % (line[0], line[2]),
+                file=sys.stderr,
+            )
+            continue
+
+        try:
+            options[line[0]] = line[2](options[line[0]])
+        except Exception:
+            raise ge.CommandError(
+                command,
+                "Invalid parameter value!",
+                "Parameter `%s` is specified but is set to an invalid value:"
+                % (line[0]),
+                "---> %s=%s" % (line[0], str(options[line[0]])),
+                "Please check acceptable inputs for %s!" % (line[0]),
+            )
 
     # impute unspecified parameters. An imputed value stays "default": nobody
     # specified it, which is what the source says

--- a/python/qx_utilities/general/run_bash.py
+++ b/python/qx_utilities/general/run_bash.py
@@ -71,7 +71,13 @@ def run(qx_command, args, run=None, session=None):
 
     # -- resolve script path
 
-    script = os.path.join(os.environ.get('QUNEXPATH', ''), 'bash', qx_command.path)
+    # the registry the command came from says where its `bash` folder is -- the
+    # extension's own folder for an extension command, $QUNEXPATH for a core
+    # one. Resolving against $QUNEXPATH alone sent every extension command to
+    # the core install, where its script is not. The fallback is for a record
+    # built by hand rather than loaded, which only a test does
+    root = getattr(qx_command, 'root', None) or os.environ.get('QUNEXPATH', '')
+    script = os.path.join(root, 'bash', qx_command.path)
 
     if not os.path.exists(script):
         print("\n\nERROR: %s failed! Script not found: %s\n" % (qx_command.name, script))

--- a/python/qx_utilities/gmri
+++ b/python/qx_utilities/gmri
@@ -29,6 +29,7 @@ if str(ROOT) not in sys.path:
 # --- continue with imports
 
 import copy
+import inspect
 import os
 import os.path
 from datetime import datetime
@@ -634,16 +635,40 @@ def main(args=None):
     opts = dict()
 
     try:
-        # the two generated files are rebuilt by name. neither command takes an
-        # option, and a bare `qunex <command>` is read as a request for help
-        # below, so both are dispatched here -- unless help is what was asked
-        # for, which still falls through
+        # the two generated files are rebuilt by name, here rather than through
+        # `runCommand`, because `build_qx_registry` has to run when there is no
+        # registry to look a command up in. A bare `qunex <command>` is read as
+        # a request for help below, so both are dispatched here -- unless help
+        # is what was asked for, which still falls through
         wants_help = any(a.strip("-") in ["h", "H", "help"] for a in args[1:])
 
         if comm == 'build_qx_registry' and not wants_help:
             print("Building command registry...")
             from qx_registry_build import build_qx_registry
-            build_qx_registry()
+
+            # the bypass above used to drop the call's options with it, so
+            # `--build_core=no` was accepted and then quietly ignored. They are
+            # read here instead, and checked against what the command takes:
+            # the check `runCommand` does for a utility command is not reached
+            # on this path either
+            for arg in args[1:]:
+                if "=" in arg:
+                    key, value = arg.split("=", 1)
+                    opts[key.strip("-")] = value
+
+            unknown = [
+                key
+                for key in opts
+                if key not in inspect.signature(build_qx_registry).parameters
+            ]
+            if unknown:
+                raise ge.CommandError(
+                    comm,
+                    "Invalid arguments",
+                    "Provided unknown arguments: [%s]!" % (", ".join(unknown)),
+                )
+
+            build_qx_registry(**opts)
             print("Command registry successfully built!")
             sys.exit(0)
 

--- a/python/tests/test_extension_roots.py
+++ b/python/tests/test_extension_roots.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# SPDX-FileCopyrightText: 2026 QuNex development team <https://qunex.yale.edu/>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+Where QuNex looks for extensions, and what an extension command resolves against.
+
+Two defects are pinned here. The folders variable was spelled
+`QUNEXEXTENSIONSFOLDERS` in the shell and `QUNEXEXTENSIONFOLDERS` here, so a root
+named in only one of them was half registered. And a bash command carried a path
+relative to the registry it came from, which nothing resolved against anything
+but `$QUNEXPATH`, so an extension's scripts were looked for in the core install.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import qx_registry
+import qx_utilities.general.run_bash as gb
+
+
+def _registry_yaml(folder: Path, *, source_id: str, name: str, path: str) -> Path:
+    """A one-command registry file at the root of what it describes."""
+    folder.mkdir(parents=True, exist_ok=True)
+    out = folder / "qx_commands.yaml"
+    out.write_text(
+        "version: 1\n"
+        "generated_at: '2026-01-01T00:00:00Z'\n"
+        "source:\n"
+        f"    id: {source_id}\n"
+        "commands:\n"
+        f"    -   name: {name}\n"
+        f"        path: {path}\n"
+        "        language: bash\n"
+        "        type: utility\n"
+        f"        origin: {source_id}\n",
+        encoding="utf-8",
+    )
+    return out
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """No suite variables, no warnings remembered from another test."""
+    for name in (
+        "QUNEXPATH",
+        "TOOLS",
+        qx_registry.EXTENSION_FOLDERS_ENV,
+        qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED,
+    ):
+        monkeypatch.delenv(name, raising=False)
+    qx_registry._warned.clear()
+    yield
+    qx_registry._warned.clear()
+
+
+# ==============================================================================
+#                                                          the search roots (E1)
+
+
+def test_canonical_spelling_is_read(clean_env, monkeypatch, tmp_path):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(root))
+
+    assert qx_registry.extension_search_roots() == [root.resolve()]
+
+
+def test_deprecated_spelling_is_read_and_says_so(clean_env, monkeypatch, tmp_path, capsys):
+    root = tmp_path / "extensions"
+    root.mkdir()
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, str(root))
+
+    assert qx_registry.extension_search_roots() == [root.resolve()]
+
+    captured = capsys.readouterr()
+    assert qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED in captured.err
+    assert qx_registry.EXTENSION_FOLDERS_ENV in captured.err
+    # `bin/qunex.sh` reads `gmri -available` off stdout as its routing table
+    assert captured.out == ""
+
+
+def test_both_spellings_give_one_root(clean_env, monkeypatch, tmp_path):
+    """How an installation migrates: set the new name beside the old one."""
+    root = tmp_path / "extensions"
+    root.mkdir()
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(root))
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, str(root))
+
+    assert qx_registry.extension_search_roots() == [root.resolve()]
+
+
+def test_a_root_that_is_not_there_warns_and_is_skipped(clean_env, monkeypatch, tmp_path, capsys):
+    there = tmp_path / "extensions"
+    there.mkdir()
+    monkeypatch.setenv(
+        qx_registry.EXTENSION_FOLDERS_ENV, "%s:%s" % (tmp_path / "nowhere", there)
+    )
+
+    assert qx_registry.extension_search_roots() == [there.resolve()]
+    assert "nowhere" in capsys.readouterr().err
+
+
+def test_the_fixed_roots_come_first_and_do_not_warn(clean_env, monkeypatch, tmp_path, capsys):
+    """$QUNEXPATH and $TOOLS are absent on most installations; that is not news."""
+    monkeypatch.setenv("QUNEXPATH", str(tmp_path / "qunex"))
+    monkeypatch.setenv("TOOLS", str(tmp_path / "tools"))
+
+    roots = qx_registry.extension_search_roots()
+
+    assert roots == [
+        (tmp_path / "qunex" / "qx_extensions"),
+        (tmp_path / "tools" / "qx_extensions"),
+    ]
+    assert capsys.readouterr().err == ""
+
+
+# ==============================================================================
+#                                            the root a command resolves against
+
+
+def test_a_loaded_command_knows_the_folder_it_came_from(tmp_path):
+    ext = tmp_path / "qx_example"
+    yaml_path = _registry_yaml(
+        ext, source_id="extension:example", name="example_bash_greet", path="greet.sh"
+    )
+
+    registry = qx_registry.load_registry_yaml(yaml_path)
+
+    assert registry.commands[0].root == str(ext)
+
+
+def test_core_and_extension_records_keep_their_own_roots(clean_env, monkeypatch, tmp_path):
+    core = tmp_path / "qunex"
+    core_yaml = _registry_yaml(core, source_id="core", name="core_cmd", path="core.sh")
+    ext = tmp_path / "extensions" / "qx_example"
+    _registry_yaml(ext, source_id="extension:example", name="ext_cmd", path="ext.sh")
+
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(tmp_path / "extensions"))
+    merged, _tokens = qx_registry.load_qx_registry(core_registry_path=core_yaml)
+
+    roots = {c.name: c.root for c in merged.commands}
+    assert roots == {"core_cmd": str(core), "ext_cmd": str(ext.resolve())}
+
+
+# ==============================================================================
+#                                              the bash script it resolves (E2)
+
+
+def test_a_bash_command_is_looked_for_under_its_own_root(tmp_path, capsys, monkeypatch):
+    """
+    The script is not written, so `run` reports it missing and returns before
+    running anything -- the path in that message is what is under test.
+    """
+    monkeypatch.setenv("QUNEXPATH", str(tmp_path / "qunex"))
+    ext = tmp_path / "qx_example"
+    yaml_path = _registry_yaml(
+        ext, source_id="extension:example", name="example_bash_greet", path="greet.sh"
+    )
+    command = qx_registry.load_registry_yaml(yaml_path).commands[0]
+
+    assert gb.run(command, {}) == 1
+
+    reported = capsys.readouterr().out
+    assert str(ext / "bash" / "greet.sh") in reported
+    assert str(tmp_path / "qunex") not in reported
+
+
+def test_a_command_with_no_root_still_falls_back_to_qunexpath(tmp_path, capsys, monkeypatch):
+    """A record built by hand rather than loaded -- which only a test does."""
+    monkeypatch.setenv("QUNEXPATH", str(tmp_path / "qunex"))
+    command = qx_registry.CommandInfo(
+        name="core_bash_command",
+        aliases=(),
+        path="core.sh",
+        language="bash",
+        call=None,
+        description=None,
+        type="utility",
+        args=(),
+        options=(),
+        returns=(),
+        origin="core",
+    )
+
+    assert gb.run(command, {}) == 1
+    assert str(tmp_path / "qunex" / "bash" / "core.sh") in capsys.readouterr().out

--- a/python/tests/test_extensions.py
+++ b/python/tests/test_extensions.py
@@ -13,6 +13,7 @@ Where extensions are searched for, and what a command resolves its files
 against, are in `test_extension_roots.py`.
 """
 
+import os
 import sys
 
 import pytest
@@ -102,6 +103,67 @@ def test_qx_modules_still_imports_what_it_lists(restore_sys_path, monkeypatch, t
     ge.load_extensions()
 
     assert ge.compile_list("arglist") == [["example_declared", "yes", str]]
+
+
+# ==============================================================================
+#                                        what an extension puts in the environment
+
+
+@pytest.fixture
+def clean_extension_env(monkeypatch, tmp_path):
+    """An extensions root with one extension in it, and nothing inherited."""
+    extension = tmp_path / "extroot" / "qx_example"
+    (extension / "bin").mkdir(parents=True)
+    (extension / "lib").mkdir()
+
+    for name in ("QUNEXPATH", "TOOLS", "QXEXTENSIONSPY",
+                 qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED,
+                 "QXEXAMPLEPATH", "QXEXAMPLELIB", "QXEXAMPLEBIN"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(tmp_path / "extroot"))
+    monkeypatch.setenv("PATH", "/usr/bin")
+
+    return extension
+
+
+def test_an_extensions_bin_folder_reaches_path(clean_extension_env, monkeypatch):
+    """
+    A script in `bin` is not a QuNex command -- it is callable by name from
+    anything that inherits the environment, which is what an extension's own
+    code does. The environment script puts it there when it is sourced, and in
+    a container that is once, before any extension is installed.
+    """
+    ge.register_extension_paths()
+
+    binaries = str(clean_extension_env / "bin")
+    assert os.environ["PATH"].split(os.pathsep)[0] == binaries
+    assert os.environ["QXEXAMPLEBIN"] == binaries
+
+
+def test_an_extension_is_named_in_the_environment(clean_extension_env):
+    ge.register_extension_paths()
+
+    assert os.environ["QXEXAMPLEPATH"] == str(clean_extension_env)
+    assert os.environ["QXEXAMPLELIB"] == str(clean_extension_env / "lib")
+
+
+def test_the_bin_folder_is_added_once(clean_extension_env):
+    ge.register_extension_paths()
+    ge.register_extension_paths()
+
+    binaries = str(clean_extension_env / "bin")
+    assert os.environ["PATH"].split(os.pathsep).count(binaries) == 1
+
+
+def test_an_extension_without_lib_or_bin_names_only_itself(clean_extension_env):
+    (clean_extension_env / "bin").rmdir()
+    (clean_extension_env / "lib").rmdir()
+
+    ge.register_extension_paths()
+
+    assert os.environ["QXEXAMPLEPATH"] == str(clean_extension_env)
+    assert "QXEXAMPLEBIN" not in os.environ
+    assert "QXEXAMPLELIB" not in os.environ
 
 
 # ==============================================================================

--- a/python/tests/test_extensions.py
+++ b/python/tests/test_extensions.py
@@ -20,6 +20,7 @@ import pytest
 import qx_registry
 import qx_utilities.general.commands_support as gcs
 import qx_utilities.general.extensions as ge
+import qx_utilities.general.matlab as gm
 import qx_utilities.general.process as gp
 
 from .test_extension_roots import _registry_yaml
@@ -54,6 +55,39 @@ def test_the_python_folder_is_added_without_qx_modules(
     assert str(py) in sys.path
 
 
+def test_an_extension_is_found_without_the_environment(restore_sys_path, monkeypatch, tmp_path):
+    """
+    The environment script exports `QXEXTENSIONSPY`, and inside a container it
+    is sourced once -- every later source returns immediately -- so an
+    extension installed after the container started never reaches it. The
+    search roots answer the same question without the environment.
+    """
+    py = tmp_path / "extroot" / "qx_example" / "python"
+    py.mkdir(parents=True)
+    monkeypatch.delenv("QXEXTENSIONSPY", raising=False)
+    monkeypatch.delenv("QUNEXPATH", raising=False)
+    monkeypatch.delenv("TOOLS", raising=False)
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, raising=False)
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(tmp_path / "extroot"))
+
+    assert ge.extension_python_folders() == [str(py)]
+
+    ge.load_extensions()
+    assert str(py) in sys.path
+
+
+def test_a_folder_named_both_ways_is_listed_once(restore_sys_path, monkeypatch, tmp_path):
+    py = tmp_path / "extroot" / "qx_example" / "python"
+    py.mkdir(parents=True)
+    monkeypatch.delenv("QUNEXPATH", raising=False)
+    monkeypatch.delenv("TOOLS", raising=False)
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, raising=False)
+    monkeypatch.setenv("QXEXTENSIONSPY", str(py))
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(tmp_path / "extroot"))
+
+    assert ge.extension_python_folders() == [str(py)]
+
+
 def test_qx_modules_still_imports_what_it_lists(restore_sys_path, monkeypatch, tmp_path):
     py = tmp_path / "qx_example" / "python"
     py.mkdir(parents=True)
@@ -68,6 +102,53 @@ def test_qx_modules_still_imports_what_it_lists(restore_sys_path, monkeypatch, t
     ge.load_extensions()
 
     assert ge.compile_list("arglist") == [["example_declared", "yes", str]]
+
+
+# ==============================================================================
+#                                       where an extension's matlab code is found
+
+
+def _matlab_command(tmp_path, *, origin, matlabpaths=None):
+    ext = tmp_path / "qx_example"
+    matlab = ext / "matlab"
+    matlab.mkdir(parents=True)
+    if matlabpaths is not None:
+        (matlab / "extra").mkdir()
+        (matlab / "matlabpaths").write_text(matlabpaths, encoding="utf-8")
+
+    return qx_registry.CommandInfo(
+        name="example_matlab_greet",
+        aliases=(),
+        path="example_matlab_greet.m",
+        language="matlab",
+        call=None,
+        description=None,
+        type="matlab",
+        args=(),
+        options=(),
+        returns=(),
+        origin=origin,
+        root=str(ext),
+    )
+
+
+def test_an_extension_matlab_command_finds_its_own_folder(tmp_path):
+    command = _matlab_command(tmp_path, origin="extension:example")
+
+    assert gm.extension_matlab_folders(command) == [str(tmp_path / "qx_example" / "matlab")]
+
+
+def test_matlabpaths_adds_what_it_lists(tmp_path):
+    command = _matlab_command(tmp_path, origin="extension:example", matlabpaths="extra\n\n")
+
+    matlab = tmp_path / "qx_example" / "matlab"
+    assert gm.extension_matlab_folders(command) == [str(matlab), str(matlab / "extra")]
+
+
+def test_a_core_matlab_command_is_left_to_the_environment(tmp_path):
+    command = _matlab_command(tmp_path, origin="core")
+
+    assert gm.extension_matlab_folders(command) == []
 
 
 # ==============================================================================

--- a/python/tests/test_extensions.py
+++ b/python/tests/test_extensions.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+# SPDX-FileCopyrightText: 2026 QuNex development team <https://qunex.yale.edu/>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+What an extension declares, how its commands are reached, and what a run says
+about where its command came from.
+
+Where extensions are searched for, and what a command resolves its files
+against, are in `test_extension_roots.py`.
+"""
+
+import sys
+
+import pytest
+
+import qx_registry
+import qx_utilities.general.commands_support as gcs
+import qx_utilities.general.extensions as ge
+import qx_utilities.general.process as gp
+
+from .test_extension_roots import _registry_yaml
+
+
+# ==============================================================================
+#                          the python folder reaches sys.path without qx_modules
+
+
+@pytest.fixture
+def restore_sys_path():
+    """`load_extensions` appends to `sys.path` and never takes anything off."""
+    before = list(sys.path)
+    yield
+    sys.path[:] = before
+
+
+def test_the_python_folder_is_added_without_qx_modules(
+    restore_sys_path, monkeypatch, tmp_path
+):
+    """
+    A python command's registry path is dotted relative to this folder and
+    nothing else ever adds it, so gating it on `qx_modules` left an extension
+    whose commands were listed and dispatched and then failed to import.
+    """
+    py = tmp_path / "qx_example" / "python"
+    py.mkdir(parents=True)
+    monkeypatch.setenv("QXEXTENSIONSPY", str(py))
+
+    ge.load_extensions()
+
+    assert str(py) in sys.path
+
+
+def test_qx_modules_still_imports_what_it_lists(restore_sys_path, monkeypatch, tmp_path):
+    py = tmp_path / "qx_example" / "python"
+    py.mkdir(parents=True)
+    (py / "qx_example_declarations.py").write_text(
+        "arglist = [['example_declared', 'yes', str]]\n", encoding="utf-8"
+    )
+    (py / "qx_modules").write_text("# a comment\n\nqx_example_declarations\n", encoding="utf-8")
+    monkeypatch.setenv("QXEXTENSIONSPY", str(py))
+    monkeypatch.setattr(ge, "module_names", [])
+    monkeypatch.setattr(ge, "modules", {})
+
+    ge.load_extensions()
+
+    assert ge.compile_list("arglist") == [["example_declared", "yes", str]]
+
+
+# ==============================================================================
+#                                                    what an arglist entry says
+
+
+def test_a_four_element_entry_gets_its_default_and_its_converter(monkeypatch):
+    """
+    The form the extension documentation teaches, with a description last.
+    Reading three-element entries only left a parameter declared this way with
+    no default and no type at all, which a command then read as a `KeyError`.
+    """
+    monkeypatch.setattr(
+        gp, "arglist", gp.arglist + [["example_times", "2", int, "How many times."]]
+    )
+
+    options, sources, _stated = gp.merge_options("example_hello", {})
+
+    assert options["example_times"] == 2
+    assert sources["example_times"] == "default"
+
+
+def test_a_three_element_entry_is_unchanged(monkeypatch):
+    monkeypatch.setattr(gp, "arglist", gp.arglist + [["example_times", "3", int]])
+
+    options, _sources, _stated = gp.merge_options("example_hello", {})
+
+    assert options["example_times"] == 3
+
+
+def test_a_converter_that_can_not_be_called_is_reported_and_skipped(monkeypatch, capsys):
+    """
+    This runs over the whole arglist on every invocation of every command, so a
+    declaration QuNex can not honour has to cost one line rather than the run.
+    A parameter annotation reaching here as the converter is how it happens.
+    """
+    monkeypatch.setattr(
+        gp, "arglist", gp.arglist + [["example_annotated", "raw", "int", "Annotated."]]
+    )
+
+    options, _sources, _stated = gp.merge_options("example_hello", {})
+
+    assert options["example_annotated"] == "raw"
+    assert "example_annotated" in capsys.readouterr().err
+
+
+def test_a_heading_is_still_a_heading(monkeypatch):
+    monkeypatch.setattr(gp, "arglist", gp.arglist + [["# ---- example settings"]])
+
+    options, _sources, _stated = gp.merge_options("example_hello", {})
+
+    assert "# ---- example settings" not in options
+
+
+def test_qx_process_declares_the_parameters_it_wraps(monkeypatch):
+    """
+    The decorator no longer registers a command -- a docstring block and a
+    registry build do that -- but the keyword arguments of what it wraps still
+    reach `arglist`, which is the one thing it was still doing. The entries it
+    writes carry a description, so they are the four-element form above.
+    """
+    monkeypatch.setattr(ge, "arglist", [])
+
+    @ge.qx_process()
+    def example_greet_sessions(sinfo, options, example_times: int = 2, overwrite=False, thread=0):
+        return None
+
+    # `options` is the dictionary the command is handed, not a parameter
+    assert ge.arglist == [["example_times", 2, int, ""]]
+
+
+def test_qx_process_says_no_when_the_signature_is_wrong(monkeypatch, capsys):
+    monkeypatch.setattr(ge, "arglist", [])
+
+    @ge.qx_process()
+    def not_a_processing_command(options, overwrite=False, thread=0):
+        return None
+
+    assert ge.arglist == []
+    assert "not_a_processing_command" in capsys.readouterr().out
+
+
+# ==============================================================================
+#                                              the routing table `bin/qunex.sh`
+
+
+def test_an_alias_is_offered_for_routing(tmp_path, monkeypatch):
+    """
+    `bin/qunex.sh` matches the typed word against this list, so a command whose
+    alias is missing from it answers "Requested command is not supported" while
+    `gmri`, which resolves through the token map, runs it.
+    """
+    core = tmp_path / "qunex"
+    core_yaml = _registry_yaml(core, source_id="core", name="dwi_f99", path="f99.sh")
+    core_yaml.write_text(
+        core_yaml.read_text(encoding="utf-8").replace(
+            "        language: bash\n", "        language: bash\n        aliases:\n            - f99\n"
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV, raising=False)
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, raising=False)
+    monkeypatch.delenv("TOOLS", raising=False)
+    monkeypatch.setenv("QUNEXPATH", str(core))
+
+    registry = qx_registry.load_command_registry(core_registry_path=core_yaml)
+
+    assert set(registry.gmri_commands()) == {"dwi_f99", "f99"}
+
+
+def test_run_turnkey_is_still_kept_out(tmp_path, monkeypatch):
+    core = tmp_path / "qunex"
+    core_yaml = _registry_yaml(
+        core, source_id="core", name="run_turnkey", path="run_turnkey.sh"
+    )
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV, raising=False)
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, raising=False)
+    monkeypatch.delenv("TOOLS", raising=False)
+    monkeypatch.setenv("QUNEXPATH", str(core))
+
+    registry = qx_registry.load_command_registry(core_registry_path=core_yaml)
+
+    assert registry.gmri_commands() == []
+
+
+# ==============================================================================
+#                                        what the run says about its own command
+
+
+def _load(tmp_path, monkeypatch, *, ext_command):
+    """Core with `check_study`, and an extension providing `ext_command`."""
+    core = tmp_path / "qunex"
+    core_yaml = _registry_yaml(core, source_id="core", name="check_study", path="check.sh")
+    ext = tmp_path / "extensions" / "qx_example"
+    _registry_yaml(ext, source_id="extension:example", name=ext_command, path="ext.sh")
+
+    monkeypatch.delenv("TOOLS", raising=False)
+    monkeypatch.delenv(qx_registry.EXTENSION_FOLDERS_ENV_DEPRECATED, raising=False)
+    monkeypatch.setenv("QUNEXPATH", str(core))
+    monkeypatch.setenv(qx_registry.EXTENSION_FOLDERS_ENV, str(tmp_path / "extensions"))
+
+    return qx_registry.load_command_registry(core_registry_path=core_yaml)
+
+
+def test_a_core_command_says_nothing(tmp_path, monkeypatch):
+    registry = _load(tmp_path, monkeypatch, ext_command="example_hello")
+
+    assert gcs.report_origin(registry.require("check_study")) == ""
+
+
+def test_an_extension_command_names_its_extension(tmp_path, monkeypatch):
+    registry = _load(tmp_path, monkeypatch, ext_command="example_hello")
+
+    reported = gcs.report_origin(registry.require("example_hello"))
+
+    assert "example_hello" in reported
+    assert "extension example" in reported
+    assert "replacing" not in reported
+
+
+def test_an_override_says_what_it_replaced(tmp_path, monkeypatch):
+    """
+    The case with no other signal: same name, same parameter table, same runlog.
+    """
+    registry = _load(tmp_path, monkeypatch, ext_command="check_study")
+
+    reported = gcs.report_origin(registry.require("check_study"))
+
+    assert "replacing the core command of the same name" in reported
+
+
+def test_the_banner_carries_the_line(tmp_path, monkeypatch):
+    registry = _load(tmp_path, monkeypatch, ext_command="check_study")
+    command = registry.require("check_study")
+
+    banner = gcs.report_parameters(command, {"sessions": "s01"}, {"sessions": "command line"})
+
+    assert "is provided by extension example" in banner
+    assert banner.index("provided by extension") < banner.index("Parameters for")

--- a/qx_commands.yaml
+++ b/qx_commands.yaml
@@ -1,5 +1,5 @@
 version: 1
-generated_at: '2026-08-14T09:56:47.360917+00:00'
+generated_at: '2026-08-21T18:07:51.724338+00:00'
 source:
     id: core
 commands:
@@ -139,32 +139,37 @@ commands:
     args:
     -   name: core_python_root
         type: Optional[str | Path]
-        default: null
-        description: null
+        default: ''
+        description: The folder to index the core python commands from. Defaults to $QUNEXPATH/python.
     -   name: core_registry_yaml
         type: Optional[str | Path]
-        default: null
-        description: null
+        default: ''
+        description: The file to write the core registry to. Defaults to $QUNEXPATH/qx_commands.yaml.
+    -   name: build_core
+        type: bool
+        default: 'yes'
+        description: Whether to build the core registry. Set to 'no' to leave the core registry alone and build only the extensions,
+            which is what an extension author wants and what a read-only installation requires.
     -   name: build_extensions
         type: bool
-        default: null
-        description: null
+        default: 'yes'
+        description: Whether to build the registry of every extension found. Set to 'no' to build only core.
     -   name: extension_registry_filename
         type: str
-        default: null
-        description: null
+        default: qx_commands.yaml
+        description: The name of the registry file written inside each extension.
     -   name: extension_python_subdir
         type: str
-        default: null
-        description: null
+        default: python
+        description: The folder inside an extension holding its python commands.
     -   name: extension_matlab_subdir
         type: str
-        default: null
-        description: null
+        default: matlab
+        description: The folder inside an extension holding its MATLAB commands.
     -   name: extension_bash_subdir
         type: str
-        default: null
-        description: null
+        default: bash
+        description: The folder inside an extension holding its bash commands.
     options: []
     returns:
     -   name: registry


### PR DESCRIPTION

## Extensions that work

### What was wrong

An extension no longer registers its commands. Since the command registry arrived, a
function in an extension becomes a QuNex command by carrying a `.. qx_command:` block in
its docstring, exactly as a core command does, and `qunex build_qx_registry` indexes it.
That is a good deal simpler than what came before — and, as it turns out, it had never
been exercised end to end. Writing the extension documentation was the first time
somebody built an extension from scratch, ran each kind of command in it, and watched
what happened. Eight defects came out of that, two of which stopped an extension working
at all.

The search root was named by one environment variable spelled two different ways:
`QUNEXEXTENSIONSFOLDERS` in the shell, `QUNEXEXTENSIONFOLDERS` — no second S — in python.
An extension named in only one of them was half installed. Under the shell spelling it
got `PATH`, `MATLABPATH` and `QXEXTENSIONSPY` but no registry, so its commands were not
known at all; under the python spelling the commands were known and dispatched and then
failed to import. Only the two fixed roots, `$QUNEXPATH/qx_extensions` and
`$TOOLS/qx_extensions`, are hard coded in both halves, which is why this had gone
unnoticed. Separately, an extension's **bash** commands could not run: `run_bash`
resolved a script as `$QUNEXPATH/bash/<path>`, always the core installation, while the
registry records a path relative to the folder the command was indexed from, so the
script was looked for where it is not.

The remaining six did not stop an extension working, but between them they made one
hard to write and its failures hard to read. A python command needed a `python/qx_modules`
file or it would be listed, dispatched, reported and only then fail on import. A
parameter declared the way the documentation taught — `["name", "default", str,
"description"]`, four elements — was silently ignored, so a command reading it raised
`KeyError` unless the user named it on the command line. A command's aliases did not work
through `qunex`. A run gave no sign that its command came from an extension, even when
that command was standing in for a core command of the same name. And an extension could
not be registered without rewriting the core registry, which an extension author does not
want and a read-only installation does not allow.

### What this branch changes

**One name for the search roots.** `QUNEXEXTENSIONSFOLDERS` is canonical and both halves
read it. `QUNEXEXTENSIONFOLDERS` is still accepted, so an installation that sets it keeps
working, and using it prints a deprecation notice naming the spelling to move to. A
folder that is named but is not there is now reported rather than passed over in silence,
and a folder named under both spellings — which is how an installation migrates —
registers its extension once rather than twice.

**A command finds its own files.** The registry a command came from is the answer to
where its code lives, so each command record now carries the root of that registry,
filled in when the registry is read. The registry file sits at the root of what it
describes — `<extension>/qx_commands.yaml` for an extension, `$QUNEXPATH/qx_commands.yaml`
for core — so one rule serves both with no special case. `run_bash` resolves
`<root>/bash/<path>`; an extension's python folder goes on `sys.path` whether or not it
has a `qx_modules` file; its `matlab` folder, and whatever its `matlabpaths` lists, is
added for the duration of a MATLAB call; its `bin` folder is prepended to `PATH`, and
`<EXT>PATH`, `<EXT>LIB` and `<EXT>BIN` are set, for the QuNex process and everything it
starts.

That last group matters more than it looks. The environment script does all of this when
it is sourced, and inside a container it is sourced exactly once, when the container
starts, with every later source returning immediately. An extension installed after that
point could never reach the environment, and no amount of re-sourcing helped. Now it does
not have to: everything QuNex needs to run an extension's command comes from the registry.

**Declarations take effect.** An `arglist` entry of three elements or more gets its
default and its converter, so the four-element form works. The format comment heading
`process.arglist` is where that form came from — it announced "a list of four values" and
then described three — and now describes what it accepts. Because that recode runs over
the whole `arglist` on every invocation of every command, an entry whose third element is
not callable is reported once and left unconverted rather than failing the suite.

**A run says where its command came from.** When a command is not core, one line above
the parameter table names the extension that provided it, and says what it replaced when
it stands in for a core command of the same name. The information was always in the
registry; it was simply never reported.

**Aliases route through `qunex`.** `gmri -available` is read by `bin/qunex.sh` as its
routing table, and it reported canonical names only, so an alias answered "Requested
command is not supported" while `gmri` ran it. It now reports each command's aliases
beside its name. This one is not extension-specific — core's `f99` failed the same way.

**An extension can be built on its own.** `qunex build_qx_registry --build_core=no`
builds the extensions and leaves the core registry untouched. The parameter alone was not
enough: `gmri` dispatches this command before the registry is loaded, as it must, since
the command builds the registry it would otherwise be looked up in — and that bypass
called it with no arguments at all, so no option had ever reached it from the command
line. The bypass now reads the call's options and checks them against the signature. The
command has also gained the `Parameters:` block it never had.

**The pre-registry declaration surface is gone.** Nothing had read the `commands`
dictionary, the `qx` decorator or the `calist`/`salist`/`lalist`/`malist` lists since the
registry arrived. `qx_process` keeps its name and does the one thing it still did, turning
a function's keyword arguments into `arglist` entries; its command-registration arguments
are accepted and inert so that an extension written against the older decorator still
imports.

### The parts where the reasoning is not obvious

**The root is resolved when a registry is read, not written when it is built.** Nothing
is added to any `qx_commands.yaml`, so no committed registry changes and none has to be
rebuilt. More usefully, it makes a built extension portable: an extension prepared on a
host, registry and all, can be bound into a container at any path and its commands
resolve against wherever it landed. Writing an absolute path at build time would have
made the file stale the moment the extension moved.

**The deprecation notice goes to stderr.** `bin/qunex.sh` reads `gmri -available` off
stdout as its routing table, so a line printed there would be taken for a command name.

**Where extensions are searched for lives in its own module.** `general/__init__.py`
loads the extensions as it is read, and `qx_registry` imports `general.exceptions`, so
`load_extensions` runs while `qx_registry` is still half built and cannot import a name
from it — from inside a function no less than at the top of the file.
`python/qx_extension_paths.py` imports nothing from QuNex and both halves import it. The
two environment variable names live there too, which is the point: one variable spelled
two ways is the defect that started this work, and a second copy of the lookup would have
been the same mistake in a new place.

**What the process environment can and cannot reach.** Putting an extension's `bin`
folder on `PATH` covers everything QuNex runs — a bash command, a MATLAB call, a
subprocess an extension's own python code spawns. It does not reach the shell QuNex was
called from, because no process can change its parent's environment. An extension bound
into place before a container starts is registered by the environment script as usual and
is on `PATH` at the prompt as well.

### Compatibility

`QUNEXEXTENSIONFOLDERS` keeps working and warns. No registry file changes format, and the
only difference in the committed `qx_commands.yaml` is `build_qx_registry`'s own new
docstring.

One thing to know for extension authors: a module importing `qx`, `commands`, `calist`,
`salist`, `lalist` or `malist` from `general.extensions` will now fail to import, and
`load_extensions` skips a module it cannot import — taking that module's `arglist`,
`flaglist` and deprecations with it behind a single warning line. Nothing that worked
stops working, since none of those names did anything, but such an import has to be
deleted. Worth a line in the release notes.

### Testing

Two test files, 32 tests, none of which needs a container or any data: the search roots
under each spelling and both, a root that is not there, the root stamped onto loaded core
and extension records, `run_bash` looking under the extension rather than the install,
the python folder reaching `sys.path` without `qx_modules`, `bin` reaching `PATH`, the
MATLAB folders, three- and four-element `arglist` entries and a converter that cannot be
called, aliases in the routing table, and the origin line for a plain extension command
and for one overriding core. The suite is at 837 passed, 1 skipped; `ruff` is clean.

Beyond that, the whole thing was run in `qunex_suite-latest.sif` against the example
extension: prepared and built on the host, bound onto `$TOOLS/qx_extensions` at container
start with no environment variable set, and its python, MATLAB and bash commands and its
`bin` script all run.

### Documentation

The extension mechanism is documented in the SDK wiki — a standalone extensions
whitepaper and a developer section — with a short user-facing section in the main wiki,
and a worked example extension, `Examples/qx_example`, that carries python, MATLAB and
bash commands and is the one used for the testing above. Those come through the wiki
repositories rather than this pull request.
